### PR TITLE
npm warns that gulp is defined twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Automatic layout of video elements (publisher and subscriber) minimising white-space for the OpenTok on WebRTC API. This is intended for use with the OpenTok on WebRTC JS API.",
   "main": "gulpfile.js",
   "dependencies": {
-    "gulp": "~3.5.5"
   },
   "devDependencies": {
     "codeclimate-test-reporter": "0.0.4",


### PR DESCRIPTION
its more of a devDependency than a runtime one.